### PR TITLE
OK/キャンセル時のメッセージを入れ替えた

### DIFF
--- a/Utils.py
+++ b/Utils.py
@@ -1,7 +1,7 @@
 
 if isOK:
-    message="破棄しました"
-else:
     message="保存しました"
+else:
+    message="破棄しました"
 
     


### PR DESCRIPTION
Issue #1 の対応
OK/キャンセルがクリックされたときに表示されるメッセージの内容が逆だったため、入れ替えました。